### PR TITLE
PLUME-68: updated for plume interface >= 0.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,9 +9,9 @@
 #  does it submit to any jurisdiction.
 # 
 
-cmake_minimum_required( VERSION 3.16 FATAL_ERROR )
+cmake_minimum_required( VERSION 3.25 FATAL_ERROR )
 
-find_package( ecbuild 3.5 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild)
+find_package( ecbuild 3.13.1 REQUIRED HINTS ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/../ecbuild)
 
 project( plume_plugin_axe VERSION 0.1.0 LANGUAGES C CXX Fortran)
 
@@ -20,9 +20,9 @@ ecbuild_enable_fortran( REQUIRED MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/module )
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-ecbuild_find_package( NAME eckit  VERSION  1.18   REQUIRED )
-ecbuild_find_package( NAME atlas  VERSION  0.32   REQUIRED )
-ecbuild_find_package( NAME plume  VERSION  0.1.0  REQUIRED )               
+ecbuild_find_package( NAME eckit  VERSION  1.33.2 REQUIRED )
+ecbuild_find_package( NAME atlas  VERSION  0.46.0 REQUIRED )
+ecbuild_find_package( NAME plume  VERSION  0.5.0  REQUIRED )
 
 # by default, we build the plugin for double precision only
 ecbuild_add_option(FEATURE PLUME_PLUGINS_SINGLE_PRECISION DESCRIPTION "Compile plugin for single precision fields" DEFAULT OFF)

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Build dependencies:
 
 - C/C++ compiler (C++17)
 - Fortran 2008 compiler
-- CMake >= 3.16 --- For use and installation see http://www.cmake.org/
-- ecbuild >= 3.5 --- ECMWF library of CMake macros (https://github.com/ecmwf/ecbuild)
+- CMake >= 3.25 --- For use and installation see http://www.cmake.org/
+- ecbuild >= 3.13.1 --- ECMWF library of CMake macros (https://github.com/ecmwf/ecbuild)
 
 Runtime dependencies:
-  - eckit >= 1.18.0 (https://github.com/ecmwf/eckit)
-  - Atlas >= 0.32.0 (https://github.com/ecmwf/atlas)
-  - Plume >= 0.1.0 (https://github.com/ecmwf/plume)
+  - eckit >= 1.33.2 (https://github.com/ecmwf/eckit)
+  - Atlas >= 0.46.0 (https://github.com/ecmwf/atlas)
+  - Plume >= 0.5.0 (https://github.com/ecmwf/plume)
 
 
 # Installation

--- a/src/configs/plume-config-t21.json.in
+++ b/src/configs/plume-config-t21.json.in
@@ -3,6 +3,20 @@
         {
             "name": "AreaExtractor",
             "lib": "plume_plugin_axe.DP",
+            "parameters": [
+                [
+                    {
+                        "name": "u",
+                        "type": "ATLAS_FIELD",
+                        "height": 70
+                    },
+                    {
+                        "name": "v",
+                        "type": "ATLAS_FIELD",
+                        "height": 70
+                    }
+                ]
+            ],
             "core-config": {
                 "writer": "CovJSON",
                 "runs_every": 2,

--- a/src/configs/plume-config-t21.json.in
+++ b/src/configs/plume-config-t21.json.in
@@ -2,7 +2,7 @@
     "plugins": [
         {
             "name": "AreaExtractor",
-            "lib": "plume_plugin_axe_DP",
+            "lib": "plume_plugin_axe.DP",
             "core-config": {
                 "writer": "CovJSON",
                 "runs_every": 2,

--- a/src/configs/plume-config.json.in
+++ b/src/configs/plume-config.json.in
@@ -3,6 +3,20 @@
         {
             "name": "AreaExtractor",
             "lib": "plume_plugin_axe.DP",
+            "parameters": [
+                [
+                    {
+                        "name": "u",
+                        "type": "ATLAS_FIELD",
+                        "height": 70
+                    },
+                    {
+                        "name": "v",
+                        "type": "ATLAS_FIELD",
+                        "height": 70
+                    }
+                ]
+            ],
             "core-config": {
                 "writer": "CovJSON",
                 "runs_every": 2,

--- a/src/configs/plume-config.json.in
+++ b/src/configs/plume-config.json.in
@@ -2,7 +2,7 @@
     "plugins": [
         {
             "name": "AreaExtractor",
-            "lib": "plume_plugin_axe_DP",
+            "lib": "plume_plugin_axe.DP",
             "core-config": {
                 "writer": "CovJSON",
                 "runs_every": 2,

--- a/src/plume-plugin-axe/area_extractor.cc
+++ b/src/plume-plugin-axe/area_extractor.cc
@@ -36,8 +36,8 @@ static plume::PluginCoreBuilder<AreaExtractorCore> pluginCorelBuilderAreaExtract
 
 
 AreaExtractorCore::AreaExtractorCore(const eckit::Configuration& conf) : 
-    PluginCore(conf), 
-    config_{conf, AreaExtractor::requestedFields()},
+    PluginCore(conf),
+    coreConfig_{conf},
     runsEvery_{conf.getInt("runs_every", 1)} {
 
 }
@@ -47,11 +47,14 @@ AreaExtractorCore::~AreaExtractorCore() {}
 
 void AreaExtractorCore::setup() {
 
+    // setup the specific plugin config that includes the list of parameters available in the data
+    config_ = std::make_unique<PluginConfig>(coreConfig_, modelData().listAvailableParameters("ATLAS_FIELD"));
+
     // print requests
-    eckit::Log::info() << "AreaExtractorCore::setup() - requests: " << config_ << std::endl;
+    eckit::Log::info() << "AreaExtractorCore::setup() - requests: " << *config_ << std::endl;
 
     // prepare the field reader
-    std::vector<std::string> fieldNames = AreaExtractor::requestedFields();
+    std::vector<std::string> fieldNames = config_->parameters();
     std::vector<atlas::Field> fields;
     for(auto& name: fieldNames){
         fields.push_back(modelData().getParam<atlas::Field>(name));
@@ -61,10 +64,10 @@ void AreaExtractorCore::setup() {
     reader_ = std::make_unique<DataReader>(fields);
 
     // Extract data
-    data_.reset( reader_->extractData(config_) );
+    data_.reset( reader_->extractData(*config_) );
 
     // Construct the data writer
-    writer_.reset( DataWriterFactory::instance().build(config_.outputStrategy()) );
+    writer_.reset( DataWriterFactory::instance().build(config_->outputStrategy()) );
 }
 
 

--- a/src/plume-plugin-axe/area_extractor.cc
+++ b/src/plume-plugin-axe/area_extractor.cc
@@ -54,7 +54,7 @@ void AreaExtractorCore::setup() {
     std::vector<std::string> fieldNames = AreaExtractor::requestedFields();
     std::vector<atlas::Field> fields;
     for(auto& name: fieldNames){
-        fields.push_back(modelData().getAtlasFieldShared(name));
+        fields.push_back(modelData().getParam<atlas::Field>(name));
     }
 
     // Create the reader
@@ -71,7 +71,7 @@ void AreaExtractorCore::setup() {
 void AreaExtractorCore::run() {
 
     int procID = eckit::mpi::comm().rank();
-    int timeStep = modelData().getInt("NSTEP");
+    int timeStep = modelData().getParam<int>("NSTEP");
 
     // Check if we should run
     if (timeStep % runsEvery_ != 0) {

--- a/src/plume-plugin-axe/area_extractor.h
+++ b/src/plume-plugin-axe/area_extractor.h
@@ -24,6 +24,8 @@
 #include "user_request.h"
 #include "data_writer.h"
 
+#include "atlas/field/Field.h"
+
 
 namespace area_extractor {
 
@@ -83,12 +85,13 @@ public:
 
     plume::Protocol negotiate() override {
         plume::Protocol protocol;
-        protocol.requireAtlasVersion("0.32.0");
-        protocol.requireInt("NSTEP");
+        protocol.requireAtlasVersion("0.46.0");
+        protocol.requirePlumeVersion("0.5.0");
+        protocol.require<int>("NSTEP");
 
         // Request the necessary Atlas fields
         for (auto& fld: requestedFields()) {
-            protocol.requireAtlasField(fld);
+            protocol.require<atlas::Field>(fld);
         }
 
         return protocol;

--- a/src/plume-plugin-axe/area_extractor.h
+++ b/src/plume-plugin-axe/area_extractor.h
@@ -50,8 +50,11 @@ private:
     // runs every N steps
     int runsEvery_;
 
-    // plugin configuration
-    PluginConfig config_;
+    // raw plugin-core configuration
+    eckit::LocalConfiguration coreConfig_;
+
+    // configuration (includes e.g. list of params)
+    std::unique_ptr<PluginConfig> config_;
 
     // field reader
     std::unique_ptr<DataReader> reader_;
@@ -74,25 +77,16 @@ class AreaExtractor : public plume::Plugin {
 public:
     AreaExtractor();
 
-    static std::vector<std::string> requestedFields() {
-        std::vector<std::string> vec = {
-            "u",
-            "v",
-            "t"
-        };
-        return vec;
-    }
-
     plume::Protocol negotiate() override {
         plume::Protocol protocol;
         protocol.requireAtlasVersion("0.46.0");
         protocol.requirePlumeVersion("0.5.0");
         protocol.require<int>("NSTEP");
 
-        // Request the necessary Atlas fields
-        for (auto& fld: requestedFields()) {
-            protocol.require<atlas::Field>(fld);
-        }
+        /**
+         * @note: no Atlas fields are hard-required for this plugin
+         *        parameters must be requested through configuration
+        **/
 
         return protocol;
     }

--- a/src/plume-plugin-axe/covjson_template.h
+++ b/src/plume-plugin-axe/covjson_template.h
@@ -115,15 +115,16 @@ public:
         std::string ind(indent+2, ' ');
 
         std::string params;
+        params += std::string(""+ind+"{\n");
         for (size_t iname=0; iname<paramNames.size(); iname++){
             params += std::string(""
-                                  +ind+"{\n"
                                   +ind+"\"" + paramNames[iname] + "\" : {\n"
                                   +ind+"  \"type\": \"Parameter\"\n"
                                   +ind+"}");
             // add comma if not last
             if (iname != paramNames.size()-1) params += ",\n";
-          }
+        }
+        params += std::string("\n"+ind+"}\n");
 
         return params;
     }


### PR DESCRIPTION
This pull request updates several dependencies and refactors parts of the `AreaExtractor` plugin to ensure compatibility with newer versions of its dependencies. The most important changes include raising minimum required versions for build and runtime dependencies, updating plugin configuration files, and use newer API methods and protocol requirements.


### Contributor Declaration

By opening this pull request, I affirm the following:

* All authors agree to the [Contributor License Agreement](https://github.com/ecmwf/codex/blob/main/Legal/Contributor-License-Agreement.md).
* The code follows the project's coding standards.
* I have performed self-review and added comments where needed.
* I have added or updated tests to verify that my changes are effective and functional.
* I have run all existing tests and confirmed they pass.
 
